### PR TITLE
fix post GET params in mock api

### DIFF
--- a/web/mock/server.js
+++ b/web/mock/server.js
@@ -226,7 +226,7 @@ fastify.get(
     const limit = request.query.limit
       ? Number.parseInt(request.query.limit)
       : posts.length;
-    const offset = request.query.limit
+    const offset = request.query.offset
       ? Number.parseInt(request.query.offset)
       : 0;
 


### PR DESCRIPTION
This PR fixes the mock API `/posts` endpoint when passing the `limit` param.

Current behavior:
Setting `?limit=100` in the request produces `limit = 100` and `offset=NaN` in the mock server

Expected behavior:
Setting `?limit=100` in the request produces `limit = 100` and **`offset=0`** in the mock server